### PR TITLE
SetExecWithArgsFunc() doesn't work properly after a Reset()

### DIFF
--- a/testdb.go
+++ b/testdb.go
@@ -122,7 +122,9 @@ func StubExecError(q string, err error) {
 
 // Clears all stubbed queries, and replaced functions.
 func Reset() {
-	d.conn = newConn()
+	d.conn.queries = make(map[string]query)
+	d.conn.queryFunc = nil
+	d.conn.execFunc = nil
 	d.openFunc = nil
 }
 


### PR DESCRIPTION
Hello, thanks for the cool library.

In my tests following this pattern:

``` go
func TestSomething(t *testing.T) {
    defer testdb.Reset()
    testdb.SetExecWithArgsFunc(func(query string, args []driver.Value) (result driver.Result, err error) {
        ... 
        // this function will get called in every test, despite the reset
    })
    ...
}

func TestAnotherThing(t *testing.T) {
    defer testdb.Reset()
    testdb.SetExecWithArgsFunc(func(query string, args []driver.Value) (result driver.Result, err error) {
        ... 
        // this function will never get called, even though execFunc should be overwritten
    })
    ...
}
```

I found that it would never 'overwrite' the execFunc after a reset and always use the first one defined. I suspect that the Go SQL library caches Conns or something. Either way, I found that I could fix my issues by having Reset() not make a new conn but modify the existing one.

I imagine that this doesn't show up in your tests because you open a new DB connection for each one. I would prefer to not have to do that, so this fix was very helpful to me.
