### PR TITLE
add func to create Rows from [][]driver.Value

### DIFF
--- a/testdb.go
+++ b/testdb.go
@@ -132,14 +132,10 @@ func Conn() driver.Conn {
 }
 
 func RowsFromCSVString(columns []string, s string) driver.Rows {
-	rs := &rows{
-		columns: columns,
-		closed:  false,
-	}
-
 	r := strings.NewReader(strings.TrimSpace(s))
 	csvReader := csv.NewReader(r)
 
+	rows := [][]driver.Value{}
 	for {
 		r, err := csvReader.Read()
 
@@ -165,8 +161,17 @@ func RowsFromCSVString(columns []string, s string) driver.Rows {
 			}
 		}
 
-		rs.rows = append(rs.rows, row)
+		rows = append(rows, row)
 	}
 
-	return rs
+	return RowsFromSlice(columns, rows)
+}
+
+func RowsFromSlice(columns []string, data [][]driver.Value) driver.Rows {
+	return &rows{
+		closed:  false,
+		columns: columns,
+		rows:    data,
+		pos:     0,
+	}
 }


### PR DESCRIPTION
Sometimes it's easier to create the data in driver.Rows from correctly typed
data instead of strings. Add new func, RowsFromSlice, to allow users to
create a driver.Rows by specifying the [][]driver.Value to be
used.

Refactor RowsFromCSVString to delegate to the new func.
