### PR TITLE
make query results reusable

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -36,7 +36,9 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 		if s.queryFunc == nil && q.rows != nil {
 			s.queryFunc = func(args []driver.Value) (driver.Rows, error) {
 				if q.rows != nil {
-					return q.rows, nil
+					if rows, ok := q.rows.(*rows); ok {
+						return rows.clone(), nil
+					}
 				}
 				return nil, q.err
 			}
@@ -72,6 +74,9 @@ func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 		return c.queryFunc(query, args)
 	}
 	if q, ok := d.conn.queries[getQueryHash(query)]; ok {
+		if rows, ok := q.rows.(*rows); ok {
+			return rows.clone(), q.err
+		}
 		return q.rows, q.err
 	}
 	return nil, errors.New("Query not stubbed: " + query)

--- a/rows.go
+++ b/rows.go
@@ -12,6 +12,14 @@ type rows struct {
 	pos     int
 }
 
+func (rs *rows) clone() *rows {
+	if rs == nil {
+		return nil
+	}
+
+	return &rows{closed: false, columns: rs.columns, rows: rs.rows, pos: 0}
+}
+
 func (rs *rows) Next(dest []driver.Value) error {
 	rs.pos++
 	if rs.pos > len(rs.rows) {

--- a/testdb_test.go
+++ b/testdb_test.go
@@ -362,6 +362,38 @@ func TestStubQueryRow(t *testing.T) {
 	}
 }
 
+func TestStubQueryRowReuse(t *testing.T) {
+	defer Reset()
+
+	db, _ := sql.Open("testdb", "")
+
+	sql := "select count(*) from foo"
+	columns := []string{"count"}
+	result := `
+  5
+  `
+	StubQuery(sql, RowsFromCSVString(columns, result))
+
+	i := 0
+	rows, _ := db.Query(sql)
+	for rows.Next() {
+		i++
+	}
+	if i != 1 {
+		t.Fatal("stub query should have returned one row")
+	}
+
+	j := i
+	moreRows, _ := db.Query(sql)
+	for moreRows.Next() {
+		j++
+	}
+
+	if i == j {
+		t.Fatal("stub query did not return another set of rows")
+	}
+}
+
 func TestSetQueryFuncRow(t *testing.T) {
 	defer Reset()
 


### PR DESCRIPTION
Return a clone of the rows that are used as query results so the query can be
executed multiple times.

Fixes #6
