### PR TITLE
return rows if present when type assertion fails

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,6 +39,7 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 					if rows, ok := q.rows.(*rows); ok {
 						return rows.clone(), nil
 					}
+					return q.rows, nil
 				}
 				return nil, q.err
 			}


### PR DESCRIPTION
When the query has rows, return rows even if they can't be cloned.

Sorry, I missed this in my last contribution. This PR ensures that rows will be returned for Stmt.Query even if the rows are not of type `*testdb.rows`.
