### PR TITLE
Fix logic in implementation of Prepare()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -58,7 +58,7 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 		}
 	}
 
-	if !(s.queryFunc == nil || s.execFunc == nil) {
+	if s.queryFunc == nil && s.execFunc == nil {
 		return new(stmt), errors.New("Query not stubbed: " + query)
 	}
 


### PR DESCRIPTION
Signed-off-by: Ryan McDonald ryan.mcdonald@sendgrid.com
## Summary:

Change logic so that if both query & exec funcs are stubbed, Prepare() does not return an error "query was not stubbed"
