### PR TITLE
New callback function to alter rows.Next()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -7,6 +7,7 @@ import (
 
 type conn struct {
 	queries      map[string]query
+	errorFunc    func() error
 	queryFunc    func(query string, args []driver.Value) (driver.Rows, error)
 	execFunc     func(query string, args []driver.Value) (driver.Result, error)
 	beginFunc    func() (driver.Tx, error)

--- a/rows.go
+++ b/rows.go
@@ -32,6 +32,10 @@ func (rs *rows) Next(dest []driver.Value) error {
 		dest[i] = col
 	}
 
+	if d.conn.errorFunc != nil {
+		return d.conn.errorFunc()
+	}
+
 	return nil
 }
 

--- a/testdb.go
+++ b/testdb.go
@@ -144,6 +144,11 @@ func StubCommitError(err error) {
 	})
 }
 
+// Set your own function to be executed when rows.Next() is called.
+func SetErrorFunc(f func() error) {
+	d.conn.errorFunc = f
+}
+
 // Set your own function to be executed when tx.Rollback() is called on the default transcation. Conn() can be used to grab the global Conn object containing stubbed queries.
 func SetRollbackFunc(f func() error) {
 	d.conn.rollbackFunc = f


### PR DESCRIPTION
Introduce `SetErrorFunc()` to register a callback on `rows.Next()` iteration.

If `rows.Next()` is able to return an error, the `rows.Err()` condition can be tested.

This closes #26 